### PR TITLE
Switch-to-FormHelperText-Component

### DIFF
--- a/src/Fields/EmailQuestion.tsx
+++ b/src/Fields/EmailQuestion.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { FormControl, FormLabel, Grid, TextField } from "@mui/material";
+import {
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Grid,
+  TextField,
+} from "@mui/material";
 import { Box } from "@mui/system";
 
 export const EmailQuestion = (props: any) => {
-  const renderError = props.error?.value ? (
-    <strong>{props.error.value}</strong>
-  ) : null;
-
   return (
     <Box
       display='flex'
@@ -36,9 +38,9 @@ export const EmailQuestion = (props: any) => {
                 })
               }
               required={props.required}
-              helperText={renderError}
               error={!!props.error?.value}
             />
+            <FormHelperText>{props?.error?.value}</FormHelperText>
           </Grid>
         </Grid>
       </FormControl>

--- a/src/Fields/NameQuestion.tsx
+++ b/src/Fields/NameQuestion.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { FormControl, FormLabel, Grid, TextField } from "@mui/material";
+import {
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Grid,
+  TextField,
+} from "@mui/material";
 import { Box } from "@mui/system";
 
 export const NameQuestion = (props: any) => {
-  const renderFieldError = (name: string) =>
-    props.error?.value?.[name] ? (
-      <strong>{props.error.value[name]}</strong>
-    ) : null;
   const fieldHasError = (name: string) =>
     props.error?.value?.[name] !== undefined;
 
@@ -26,37 +28,43 @@ export const NameQuestion = (props: any) => {
           <Grid item>
             <FormLabel required={props.required}>{props.label}</FormLabel>
           </Grid>
-          <Grid item>
-            <TextField
-              type='text'
-              name={props.name}
-              placeholder={"First Name"}
-              value={props.value.value.firstName}
-              onChange={(e) =>
-                props.onSetFieldValue(props.name, {
-                  ...props.value,
-                  value: { ...props.value.value, firstName: e.target.value },
-                })
-              }
-              required={props.required}
-              helperText={renderFieldError("firstName")}
-              error={fieldHasError("firstName")}
-            />
-            <TextField
-              type='text'
-              name={props.name}
-              placeholder={"Last Name"}
-              value={props.value.value.lastName}
-              onChange={(e) =>
-                props.onSetFieldValue(props.name, {
-                  ...props.value,
-                  value: { ...props.value.value, lastName: e.target.value },
-                })
-              }
-              required={props.required}
-              helperText={renderFieldError("lastName")}
-              error={fieldHasError("lastName")}
-            />
+          <Grid container item direction='row'>
+            <Grid container direction='column' xs={6}>
+              <TextField
+                type='text'
+                fullWidth
+                name={props.name}
+                placeholder={"First Name"}
+                value={props.value.value.firstName}
+                onChange={(e) =>
+                  props.onSetFieldValue(props.name, {
+                    ...props.value,
+                    value: { ...props.value.value, firstName: e.target.value },
+                  })
+                }
+                required={props.required}
+                error={fieldHasError("firstName")}
+              />
+              <FormHelperText>{props?.error?.value?.firstName}</FormHelperText>
+            </Grid>
+            <Grid container direction='column' xs={6}>
+              <TextField
+                type='text'
+                fullWidth
+                name={props.name}
+                placeholder={"Last Name"}
+                value={props.value.value.lastName}
+                onChange={(e) =>
+                  props.onSetFieldValue(props.name, {
+                    ...props.value,
+                    value: { ...props.value.value, lastName: e.target.value },
+                  })
+                }
+                required={props.required}
+                error={fieldHasError("lastName")}
+              />
+              <FormHelperText>{props?.error?.value?.lastName}</FormHelperText>
+            </Grid>
           </Grid>
         </Grid>
       </FormControl>

--- a/src/Fields/NumberQuestion.tsx
+++ b/src/Fields/NumberQuestion.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import TextField from "@mui/material/TextField";
 import { Box } from "@mui/system";
-import { FormControl, FormLabel, Grid } from "@mui/material";
+import { FormControl, FormHelperText, FormLabel, Grid } from "@mui/material";
 
 export const NumberQuestion = (props: any) => {
-  const renderError = props.error?.value ? (
-    <strong>{props.error.value}</strong>
-  ) : null;
   return (
     <Box
       display='flex'
@@ -36,9 +33,9 @@ export const NumberQuestion = (props: any) => {
                 })
               }
               required={props.required}
-              helperText={renderError}
               error={!!props.error?.value}
             />
+            <FormHelperText>{props?.error?.value}</FormHelperText>
           </Grid>
         </Grid>
       </FormControl>

--- a/src/Fields/SelectQuestion.tsx
+++ b/src/Fields/SelectQuestion.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { FormControl, FormLabel, MenuItem, Select } from "@mui/material";
+import {
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
 import { Box } from "@mui/system";
 
 export const SelectQuestion = (props: any) => {
@@ -48,6 +54,7 @@ export const SelectQuestion = (props: any) => {
             )
           )}
         </Select>
+        <FormHelperText>{props?.error?.value}</FormHelperText>
       </FormControl>
     </Box>
   );

--- a/src/Fields/TextAreaQuestion.tsx
+++ b/src/Fields/TextAreaQuestion.tsx
@@ -1,11 +1,14 @@
 import React from "react";
-import { FormControl, FormLabel, Grid, TextField } from "@mui/material";
+import {
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Grid,
+  TextField,
+} from "@mui/material";
 import { Box } from "@mui/system";
 
 export const TextAreaQuestion = (props: any) => {
-  const renderError = props.error?.value ? (
-    <strong>{props.error.value}</strong>
-  ) : null;
   return (
     <Box
       display='flex'
@@ -36,9 +39,9 @@ export const TextAreaQuestion = (props: any) => {
                 })
               }
               required={props.required}
-              helperText={renderError}
               error={!!props.error?.value}
             />
+            <FormHelperText>{props?.error?.value}</FormHelperText>
           </Grid>
         </Grid>
       </FormControl>

--- a/src/Fields/TextQuestion.tsx
+++ b/src/Fields/TextQuestion.tsx
@@ -1,12 +1,14 @@
 import React from "react";
-import { FormControl, FormLabel, Grid, TextField } from "@mui/material";
+import {
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Grid,
+  TextField,
+} from "@mui/material";
 import { Box } from "@mui/system";
 
 export const TextQuestion = (props: any) => {
-  const renderError = props.error?.value ? (
-    <strong>{props.error.value}</strong>
-  ) : null;
-
   return (
     <Box
       display='flex'
@@ -37,9 +39,9 @@ export const TextQuestion = (props: any) => {
                 })
               }
               required={props.required}
-              helperText={renderError}
               error={!!props.error?.value}
             />
+            <FormHelperText>{props?.error?.value}</FormHelperText>
           </Grid>
         </Grid>
       </FormControl>


### PR DESCRIPTION
I discovered https://mui.com/api/form-helper-text/#main-content and that it was better to use than the way I was previously rendering errors. Especially because some inputs do not have a ```helperText``` prop.